### PR TITLE
Add a better way to handler routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 - [Introduction](#introduction)
 - [Installation](#installation)
-- [Usage](#usage)
+- [Routing](#routing)
+- [Running](#running)
 - [License](#license)
 - [Improvements](#improvements)
 
@@ -23,6 +24,78 @@ This project uses the following main libraries:
 - melange
 - styled-ppx (emotion)
 
+Keep in mind that the project is still in development and I'm not sure it's production ready.
+It's just a sample I'm having fun with. :)
+
+## Routing
+
+For a easy way to build and keep info together, this project works with getInitialProps system, that is a way to get data from server and pass to the client. Working on SPA and SSR.
+
+
+Example:
+```reason
+open DynamicRouting;
+
+loadedRoutes
+|> register(
+     ~path="/",
+     ~getInitialProps=(_) => Binding.Json.from_string("Hello World"),
+     ~component=initialProps =>
+     <h1> {ReasonReact.string(initialProps |> Binding.Json.to_string)} </h1>
+   );
+   
+// register more routes here
+
+let loadedPages = getLoadedRoutes();
+```
+
+The `~getInitialProps` has the following contract:
+```reason
+let getInitialProps: option(Bindings_Dream.request => Bindings.Js.Promise.t(Bindings.Json.t));
+```
+
+So it returns a promise with a json object and you must decode the json object to your data at the component.
+
+The idea is to in the future provide a better way to construct a prop type with buildt-in decoder, maybe with a ppx, similar to deriving yojson but universal.
+
+```reason
+// Pages_Home.re
+type props = [%json { name: string }];
+
+let json = {
+    name: "John"
+}
+
+let decodedProps = props_of_yojson(json);
+let jsonProps = props_to_yojson(decodedProps);
+
+// Pages.re
+loadedRoutes
+|> register(
+     ~path=Pages_Home.path,
+     ~getInitialProps=Pages_Home.getInitialProps,
+     ~decode=Pages_Home.decode,
+     ~component=(initialProps) => <Pages_Home.component ?initialProps />
+   );
+```
+
+That way we would be able to have a better way to handle the data and the types, no decode needed.
+
+But we still have to declare the decode for the register, the other way to improve it is to delivery a module to register the routes, so we can have a better way to organize the routes and the components.
+
+```reason
+open DynamicRouting;
+
+loadedRoutes |> register((module Pages_Home): (module Binding.DynamicRouting.LoaderPage));
+```
+
+That way we don't need to have to declare on the register the decode or any module contract, we could have a better way to organize the code.
+
+Keep in mind that:
+- I don't know if it is possible to do that with Reasonml, but it is a good idea to try.
+- I'm still learning Universal Reasonml, so it can take a while to implement it.
+- You can help me with that. :)
+
 ## Installation
 
 ```sh
@@ -35,7 +108,7 @@ With docker:
     Make docker-build
 ```
 
-## Usage
+## Running
 
 ```sh
     Make run

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fullstack Reasonml Sample
+# Fullstack ReasonML Sample
 
 ## Table of Contents
 
@@ -11,26 +11,23 @@
 
 ## Introduction
 
-This is an advanced full-stack applicaiton with Reasonml and React.
-It work as a sample project to show how to build an advanced application with Reasonml and React, with a native Reasonml server.
+This is an advanced full-stack application using ReasonML and React. It serves as a sample project to demonstrate how to build an application with ReasonML and React, including a native ReasonML server.
 
-You can access here: https://native-reason-react-advanced-80387dde2d3c.herokuapp.com/
+You can access it here: https://native-reason-react-advanced-80387dde2d3c.herokuapp.com/
 
 This project uses the following main libraries:
 
-- reasnml
+- reasonml
 - reason-react
 - server-reason-react
 - melange
 - styled-ppx (emotion)
 
-Keep in mind that the project is still in development and I'm not sure it's production ready.
-It's just a sample I'm having fun with. :)
+Keep in mind that the project is still in development and may not be production-ready. It's just a sample project I'm having fun with. :)
 
 ## Routing
 
-For a easy way to build and keep info together, this project works with getInitialProps system, that is a way to get data from server and pass to the client. Working on SPA and SSR.
-
+For an easy way to build and manage data flow, this project uses the `getInitialProps` system, which retrieves data from the server and passes it to the client. It supports both SPA and SSR functionalities.
 
 Example:
 ```reason
@@ -44,19 +41,19 @@ loadedRoutes
      <h1> {ReasonReact.string(initialProps |> Binding.Json.to_string)} </h1>
    );
    
-// register more routes here
+// Register more routes here
 
 let loadedPages = getLoadedRoutes();
 ```
 
-The `~getInitialProps` has the following contract:
+The `~getInitialProps` is defined as:
 ```reason
 let getInitialProps: option(Bindings_Dream.request => Bindings.Js.Promise.t(Bindings.Json.t));
 ```
 
-So it returns a promise with a json object and you must decode the json object to your data at the component.
+It returns a promise with a JSON object which you must decode into your data at the component level.
 
-The idea is to in the future provide a better way to construct a prop type with buildt-in decoder, maybe with a ppx, similar to deriving yojson but universal.
+The idea is to eventually provide a better way to construct a prop type with a built-in decoder, perhaps using a PPX, similar to `deriving yojson` but universal.
 
 ```reason
 // Pages_Home.re
@@ -64,7 +61,7 @@ type props = [%json { name: string }];
 
 let json = {
     name: "John"
-}
+};
 
 let decodedProps = props_of_yojson(json);
 let jsonProps = props_to_yojson(decodedProps);
@@ -79,9 +76,9 @@ loadedRoutes
    );
 ```
 
-That way we would be able to have a better way to handle the data and the types, no decode needed.
+This approach aims to streamline data handling and type management, eliminating the need for manual decoding.
 
-But we still have to declare the decode for the register, the other way to improve it is to delivery a module to register the routes, so we can have a better way to organize the routes and the components.
+However, we still need to specify the decoder when registering routes. An alternative improvement is to deliver a module for route registration, allowing for better organization of routes and components.
 
 ```reason
 open DynamicRouting;
@@ -89,35 +86,35 @@ open DynamicRouting;
 loadedRoutes |> register((module Pages_Home): (module Binding.DynamicRouting.LoaderPage));
 ```
 
-That way we don't need to have to declare on the register the decode or any module contract, we could have a better way to organize the code.
+This method simplifies route registration without specifying a decoder or any module contract, facilitating better code organization.
 
-Keep in mind that:
-- I don't know if it is possible to do that with Reasonml, but it is a good idea to try.
-- I'm still learning Universal Reasonml, so it can take a while to implement it.
-- You can help me with that. :)
+Please note:
+- I'm not sure if this is feasible with ReasonML, but it's worth exploring.
+- I'm still mastering Universal ReasonML, so implementation may take some time.
+- I welcome your collaboration. :)
 
 ## Installation
 
 ```sh
-    Make install
+    make install
 ```
 
-With docker:
+With Docker:
 
 ```sh
-    Make docker-build
+    make docker-build
 ```
 
 ## Running
 
 ```sh
-    Make run
+    make run
 ```
 
-With docker:
+With Docker:
 
 ```sh
-    Make docker-run
+    make docker-run
 ```
 
 ## License
@@ -127,9 +124,8 @@ MIT
 ## Improvements
 
 - Increase test coverage.
-    - Test custom hooks with proper testing library.
-- Increase custom Bindings.
-- Better error handling.
-- Githooks
-- CI/CD
-
+    - Test custom hooks with the appropriate testing library.
+- Enhance custom bindings.
+- Improve error handling.
+- Implement Git hooks.
+- Establish CI/CD

--- a/src/client/Routes_handler.re
+++ b/src/client/Routes_handler.re
@@ -8,11 +8,6 @@ let rec joinUrlPaths = paths =>
   | [hd, ...tail] => hd ++ "/" ++ joinUrlPaths(tail)
   };
 
-type routeDetails('a) = {
-  route: 'a,
-  initialProps: option(Shared_js_demo.Bindings.Json.t),
-};
-
 [@react.component]
 let make = (~pathMappingDetails) => {
   let url = ReasonReactRouter.useUrl();
@@ -35,8 +30,8 @@ let make = (~pathMappingDetails) => {
                 Element.innerText(el)
                 |> Shared_js_demo.Bindings.Json.from_string;
 
-              Some(data);
-            | _ => None
+              data;
+            | _ => Shared_js_demo.Bindings.Json.from_string("null")
             };
           }
         );
@@ -73,12 +68,16 @@ let make = (~pathMappingDetails) => {
                  )
               |> then_(props => {
                    setLoading(_ => false);
-                   setRenderRoute(_ => renderRouteComponent(Some(props)));
+                   setRenderRoute(_ => renderRouteComponent(props));
 
                    () |> resolve;
                  })
               |> catch(_ => {
-                   setRenderRoute(_ => renderRouteComponent(None));
+                   setRenderRoute(_ =>
+                     renderRouteComponent(
+                       Shared_js_demo.Bindings.Json.from_string("null"),
+                     )
+                   );
 
                    setLoading(_ => false);
 
@@ -88,7 +87,11 @@ let make = (~pathMappingDetails) => {
             );
           } else {
             setLoading(_ => false);
-            setRenderRoute(_ => renderRouteComponent(None));
+            setRenderRoute(_ =>
+              renderRouteComponent(
+                Shared_js_demo.Bindings.Json.from_string("null"),
+              )
+            );
           };
         };
 

--- a/src/client/Routes_handler.re
+++ b/src/client/Routes_handler.re
@@ -30,8 +30,8 @@ let make = (~pathMappingDetails) => {
                 Element.innerText(el)
                 |> Shared_js_demo.Bindings.Json.from_string;
 
-              data;
-            | _ => Shared_js_demo.Bindings.Json.from_string("null")
+              Some(data);
+            | _ => None
             };
           }
         );
@@ -68,16 +68,12 @@ let make = (~pathMappingDetails) => {
                  )
               |> then_(props => {
                    setLoading(_ => false);
-                   setRenderRoute(_ => renderRouteComponent(props));
+                   setRenderRoute(_ => renderRouteComponent(Some(props)));
 
                    () |> resolve;
                  })
               |> catch(_ => {
-                   setRenderRoute(_ =>
-                     renderRouteComponent(
-                       Shared_js_demo.Bindings.Json.from_string("null"),
-                     )
-                   );
+                   setRenderRoute(_ => renderRouteComponent(None));
 
                    setLoading(_ => false);
 
@@ -87,11 +83,7 @@ let make = (~pathMappingDetails) => {
             );
           } else {
             setLoading(_ => false);
-            setRenderRoute(_ =>
-              renderRouteComponent(
-                Shared_js_demo.Bindings.Json.from_string("null"),
-              )
-            );
+            setRenderRoute(_ => renderRouteComponent(None));
           };
         };
 

--- a/src/client/app.re
+++ b/src/client/app.re
@@ -9,7 +9,7 @@ module Main = {
       pathMappingDetails={path =>
         loadedRoutes
         |> Array.find_opt(
-             (module P: Shared_js_demo.DynamicRouting.Loader_page) =>
+             (module P: Shared_js_demo.DynamicRouting.LoaderPage) =>
              P.path == path
            )
         |> (

--- a/src/client/app.re
+++ b/src/client/app.re
@@ -1,45 +1,22 @@
-module type Route = {
-  let route: string;
-  let getInitialProps:
-    option(
-      (string => option(string)) =>
-      Shared_js_demo.Bindings.Js.Promise.t(Shared_js_demo.Bindings.Json.t),
-    );
+// allow to create page directly on Shared_js_demo.Pages
 
-  [@react.component]
-  let make: (~initialProps: Shared_js_demo.Bindings.Json.t=?) => React.element;
-};
-
-module Route = (R: Route) => {
-  let route = R.route;
-  let make = () => {
-    (
-      initialProps => {
-        switch (initialProps) {
-        | Some(props) => <R initialProps=props />
-        | None => <R />
-        };
-      },
-      Option.is_some(R.getInitialProps),
-    );
-  };
-};
-
-module PokemonRoute = Route(Shared_js_demo.Pages.Pokemon.Make);
-module PortalRoute = Route(Shared_js_demo.Pages.Portal.Make);
+let loadedRoutes = Shared_js_demo.Pages.loadedPages |> Array.of_list;
 
 module Main = {
   [@react.component]
   let make = () => {
     <Routes_handler
       pathMappingDetails={path =>
-        switch (path) {
-        | route when route == PokemonRoute.route => PokemonRoute.make()
-        | route when route == PortalRoute.route => PortalRoute.make()
-        | _ =>
-          Js.log("No matching route found");
-          ((_ => <div />), false);
-        }
+        loadedRoutes
+        |> Array.find_opt(
+             (module P: Shared_js_demo.DynamicRouting.Loader_page) =>
+             P.path == path
+           )
+        |> (
+          fun
+          | Some((module P)) => (P.make, Option.is_some(P.getInitialProps))
+          | None => ((_ => <div> {"404" |> React.string} </div>), false)
+        )
       }
     />;
   };

--- a/src/server/dune
+++ b/src/server/dune
@@ -17,6 +17,7 @@
  (preprocess
   (pps
    server-reason-react.ppx
+   lwt_ppx
    styled-ppx
    --native
    server-reason-react.melange_ppx)))

--- a/src/server/server.re
+++ b/src/server/server.re
@@ -3,16 +3,14 @@
 let loadedRoutes = Shared_native_demo.Pages.loadedPages;
 
 let dynamicRoutesList =
-  List.map(
-    (module M: Shared_native_demo.DynamicRouting.Loader_page) => {
-      Routes_build.make(
-        ~path=M.path,
-        ~renderApp=initialProps => M.make(initialProps),
-        ~getInitialProps=M.getInitialProps,
-      )
-    },
-    loadedRoutes,
-  )
+  loadedRoutes
+  |> List.map((module M: Shared_native_demo.DynamicRouting.Loader_page) => {
+       Routes_build.make(
+         ~path=M.path,
+         ~renderApp=initialProps => M.make(initialProps),
+         ~getInitialProps=M.getInitialProps,
+       )
+     })
   |> List.flatten;
 
 let handler =

--- a/src/server/server.re
+++ b/src/server/server.re
@@ -4,7 +4,7 @@ let loadedRoutes = Shared_native_demo.Pages.loadedPages;
 
 let dynamicRoutesList =
   loadedRoutes
-  |> List.map((module M: Shared_native_demo.DynamicRouting.Loader_page) => {
+  |> List.map((module M: Shared_native_demo.DynamicRouting.LoaderPage) => {
        Routes_build.make(
          ~path=M.path,
          ~renderApp=initialProps => M.make(initialProps),

--- a/src/server/server.re
+++ b/src/server/server.re
@@ -1,46 +1,24 @@
-let pokemonRoute =
-  Routes_build.make(
-    ~route=Shared_native_demo.Pages.Pokemon.Make.route,
-    ~renderApp=
-      initialProps => <Shared_native_demo.Pages.Pokemon.Make initialProps />,
-    ~initialProps=
-      switch (Shared_native_demo.Pages.Pokemon.Make.getInitialProps) {
-      | Some(getInitialProps) => getInitialProps
-      | None => (
-          _ => Lwt.return(Shared_native_demo.Bindings.Json.from_string("{}"))
-        )
-      },
-  );
+// allow to create page directly on Shared_native_demo.Pages
 
-let getFolderContent = folder => Sys.readdir(folder);
-let rec getRecursiveFolderContent = folder =>
-  getFolderContent(folder)
-  |> Array.map(file => {
-       let path = folder ++ "/" ++ file;
-       Sys.is_directory(path) ? getRecursiveFolderContent(path) : [path];
-     })
-  |> Array.to_list
-  |> List.concat;
+let loadedRoutes = Shared_native_demo.Pages.loadedPages;
 
-getRecursiveFolderContent("./src") |> List.iter(print_endline);
-
-let portalRoute =
-  Routes_build.make(
-    ~route=Shared_native_demo.Pages.Portal.Make.route,
-    ~renderApp=_ => <Shared_native_demo.Pages.Portal.Make />,
-    ~initialProps=
-      switch (Shared_native_demo.Pages.Portal.Make.getInitialProps) {
-      | Some(getInitialProps) => getInitialProps
-      | None => (
-          _ => Lwt.return(Shared_native_demo.Bindings.Json.from_string("{}"))
-        )
-      },
-  );
+let dynamicRoutesList =
+  List.map(
+    (module M: Shared_native_demo.DynamicRouting.Loader_page) => {
+      Routes_build.make(
+        ~path=M.path,
+        ~renderApp=initialProps => M.make(initialProps),
+        ~getInitialProps=M.getInitialProps,
+      )
+    },
+    loadedRoutes,
+  )
+  |> List.flatten;
 
 let handler =
   Dream.router([
     Dream.get("/public/**", Dream.static("./public")),
-    ...List.concat([pokemonRoute, portalRoute]),
+    ...dynamicRoutesList,
   ]);
 
 let interface =

--- a/src/universal/js/client-bidings/Bindings_Dream.re
+++ b/src/universal/js/client-bidings/Bindings_Dream.re
@@ -1,0 +1,6 @@
+// Dream is a server only library, so we can't use it in the client.
+// Therefor we need to create a client version of it to universalize the code.
+
+type request;
+
+let query = (_req, _name) => None;

--- a/src/universal/native/lib/Bindings.re
+++ b/src/universal/native/lib/Bindings.re
@@ -4,3 +4,4 @@ module WebApi = Bindings_WebApi;
 module Js = Bindings_Js;
 module Json = Bindings_Json;
 module Float = Bindings_Float;
+module Dream = Bindings_Dream;

--- a/src/universal/native/lib/DynamicRouting.re
+++ b/src/universal/native/lib/DynamicRouting.re
@@ -2,18 +2,12 @@ module type Loader_page = {
   let getInitialProps:
     option(Bindings_Dream.request => Bindings.Js.Promise.t(Bindings.Json.t));
   let path: string;
-  let make: Bindings_Json.t => React.element;
+  let make: option(Bindings_Json.t) => React.element;
 };
 
 let loadedRoutes: ref(list(module Loader_page)) = ref([]);
 
-let register =
-    (
-      ~path,
-      ~getInitialProps,
-      ~component: Bindings_Json.t => React.element,
-      loadedRoutes,
-    ) => {
+let register = (~path, ~getInitialProps, ~component, loadedRoutes) => {
   module R = {
     let path = path;
     let getInitialProps = getInitialProps;

--- a/src/universal/native/lib/DynamicRouting.re
+++ b/src/universal/native/lib/DynamicRouting.re
@@ -1,11 +1,11 @@
-module type Loader_page = {
+module type LoaderPage = {
   let getInitialProps:
     option(Bindings_Dream.request => Bindings.Js.Promise.t(Bindings.Json.t));
   let path: string;
   let make: option(Bindings_Json.t) => React.element;
 };
 
-let loadedRoutes: ref(list(module Loader_page)) = ref([]);
+let loadedRoutes: ref(list(module LoaderPage)) = ref([]);
 
 let register = (~path, ~getInitialProps, ~component, loadedRoutes) => {
   module R = {
@@ -14,10 +14,10 @@ let register = (~path, ~getInitialProps, ~component, loadedRoutes) => {
     let make = component;
   };
 
-  loadedRoutes := [((module R): (module Loader_page)), ...loadedRoutes^];
+  loadedRoutes := [((module R): (module LoaderPage)), ...loadedRoutes^];
 };
 
-let getLoadedRoutes = (): list(module Loader_page) =>
+let getLoadedRoutes = (): list(module LoaderPage) =>
   switch (loadedRoutes^) {
   | [] => failwith("There are no registered Pages")
   | pages => pages

--- a/src/universal/native/lib/DynamicRouting.re
+++ b/src/universal/native/lib/DynamicRouting.re
@@ -1,0 +1,30 @@
+module type Loader_page = {
+  let getInitialProps:
+    option(Bindings_Dream.request => Bindings.Js.Promise.t(Bindings.Json.t));
+  let path: string;
+  let make: Bindings_Json.t => React.element;
+};
+
+let loadedRoutes: ref(list(module Loader_page)) = ref([]);
+
+let register =
+    (
+      ~path,
+      ~getInitialProps,
+      ~component: Bindings_Json.t => React.element,
+      loadedRoutes,
+    ) => {
+  module R = {
+    let path = path;
+    let getInitialProps = getInitialProps;
+    let make = component;
+  };
+
+  loadedRoutes := [((module R): (module Loader_page)), ...loadedRoutes^];
+};
+
+let getLoadedRoutes = (loadedRoutes): list(module Loader_page) =>
+  switch (loadedRoutes^) {
+  | [] => failwith("There are no registered Pages")
+  | pages => pages
+  };

--- a/src/universal/native/lib/DynamicRouting.re
+++ b/src/universal/native/lib/DynamicRouting.re
@@ -23,7 +23,7 @@ let register =
   loadedRoutes := [((module R): (module Loader_page)), ...loadedRoutes^];
 };
 
-let getLoadedRoutes = (loadedRoutes): list(module Loader_page) =>
+let getLoadedRoutes = (): list(module Loader_page) =>
   switch (loadedRoutes^) {
   | [] => failwith("There are no registered Pages")
   | pages => pages

--- a/src/universal/native/lib/Pages.re
+++ b/src/universal/native/lib/Pages.re
@@ -1,15 +1,16 @@
 open DynamicRouting;
 
-loadedRoutes |> register(
-  ~path=Pages_Pokemon.path,
-  ~getInitialProps=Pages_Pokemon.getInitialProps,
-  ~component=initialProps => <Pages_Pokemon initialProps />,
-);
+loadedRoutes
+|> register(
+     ~path=Pages_Pokemon.path,
+     ~getInitialProps=Pages_Pokemon.getInitialProps,
+     ~component=initialProps =>
+     <Pages_Pokemon ?initialProps />
+   );
 
-loadedRoutes |> register(
-  ~path=Pages_Portal.path,
-  ~getInitialProps=None,
-  ~component=_ => <Pages_Portal />,
-);
+loadedRoutes
+|> register(~path=Pages_Portal.path, ~getInitialProps=None, ~component=_ =>
+     <Pages_Portal />
+   );
 
 let loadedPages = getLoadedRoutes();

--- a/src/universal/native/lib/Pages.re
+++ b/src/universal/native/lib/Pages.re
@@ -1,2 +1,15 @@
-module Pokemon = Pages_Pokemon;
-module Portal = Pages_Portal;
+DynamicRouting.register(
+  ~path=Pages_Pokemon.path,
+  ~getInitialProps=Pages_Pokemon.getInitialProps,
+  ~component=initialProps => <Pages_Pokemon initialProps />,
+  DynamicRouting.loadedRoutes,
+);
+
+DynamicRouting.register(
+  ~path=Pages_Portal.path,
+  ~getInitialProps=None,
+  ~component=_ => <Pages_Portal />,
+  DynamicRouting.loadedRoutes,
+);
+
+let loadedPages = DynamicRouting.getLoadedRoutes(DynamicRouting.loadedRoutes);

--- a/src/universal/native/lib/Pages.re
+++ b/src/universal/native/lib/Pages.re
@@ -1,15 +1,15 @@
-DynamicRouting.register(
+open DynamicRouting;
+
+loadedRoutes |> register(
   ~path=Pages_Pokemon.path,
   ~getInitialProps=Pages_Pokemon.getInitialProps,
   ~component=initialProps => <Pages_Pokemon initialProps />,
-  DynamicRouting.loadedRoutes,
 );
 
-DynamicRouting.register(
+loadedRoutes |> register(
   ~path=Pages_Portal.path,
   ~getInitialProps=None,
   ~component=_ => <Pages_Portal />,
-  DynamicRouting.loadedRoutes,
 );
 
-let loadedPages = DynamicRouting.getLoadedRoutes(DynamicRouting.loadedRoutes);
+let loadedPages = getLoadedRoutes();

--- a/src/universal/native/lib/Pages/Pages_Pokemon.re
+++ b/src/universal/native/lib/Pages/Pages_Pokemon.re
@@ -78,52 +78,53 @@ let initialPropsDefault =
     |},
   );
 
-module Make = {
-  let route = "/pokemon";
+let path = "/pokemon";
 
-  let getInitialProps =
-    Some(
-      query => {
-        let name =
-          switch (query("name")) {
-          | Some(name) => name
-          | None => "bulbasaur"
-          };
+// Runs only on the server
+// but we keep it close to the component
+// to a better overview of the page
+let getInitialProps =
+  Some(
+    req => {
+      let name =
+        switch (Bindings_Dream.query(req, "name")) {
+        | Some(name) => name
+        | None => "bulbasaur"
+        };
 
-        Services.GetPokemon.make(name);
-      },
-    );
+      Services.GetPokemon.make(name);
+    },
+  );
 
-  type props = Services.GetPokemon.pokemon;
+type props = Services.GetPokemon.pokemon;
 
-  [@react.component]
-  let make = (~initialProps=initialPropsDefault) => {
-    let props: props = initialProps |> Services.GetPokemon.decodeJson;
+[@react.component]
+let make = (~initialProps=initialPropsDefault) => {
+  let props: props = initialProps |> Services.GetPokemon.decodeJson;
 
-    <Components.Layout>
-      <Components.Head>
-        <title> {"Pokemon: " ++ props.name ++ "" |> React.string} </title>
-      </Components.Head>
-      <div className=Styles.pokemon>
-        <div className=Styles.pokemonCard>
-          <h1> {props.name |> React.string} </h1>
-          <img
-            className=Styles.pokemonImage
-            src={props.sprites.other.dream_world.front_default}
-            alt={props.name}
-          />
-          <ul className=Styles.abilitiesClass>
-            {props.abilities
-             |> List.map((ab: Services.GetPokemon.abilityRecord) => {
-                  <li className=Styles.ability key={ab.ability.name}>
-                    {ab.ability.name |> React.string}
-                  </li>
-                })
-             |> Array.of_list
-             |> React.array}
-          </ul>
-        </div>
+  <Components.Layout>
+    <Components.Head>
+      <title> {"Pokemon: " ++ props.name ++ "" |> React.string} </title>
+    </Components.Head>
+    <div className=Styles.pokemon>
+      <div className=Styles.pokemonCard>
+        <h1> {props.name |> React.string} </h1>
+        <img
+          className=Styles.pokemonImage
+          src={props.sprites.other.dream_world.front_default}
+          alt={props.name}
+        />
+        <ul className=Styles.abilitiesClass>
+          {props.abilities
+           |> List.map((ab: Services.GetPokemon.abilityRecord) => {
+                <li className=Styles.ability key={ab.ability.name}>
+                  {ab.ability.name |> React.string}
+                </li>
+              })
+           |> Array.of_list
+           |> React.array}
+        </ul>
       </div>
-    </Components.Layout>;
-  };
+    </div>
+  </Components.Layout>;
 };

--- a/src/universal/native/lib/Pages/Pages_Portal.re
+++ b/src/universal/native/lib/Pages/Pages_Portal.re
@@ -38,53 +38,50 @@ module Styles = {
   ];
 };
 
-module Make = {
-  let route = "/";
+let path = "/";
 
-  let getInitialProps = None;
+[@react.component]
+let make = () => {
+  let (modalOpen, setModalOpen) = React.useState(_ => true);
+  let buttonRef = React.useRef(Bindings.Js.Nullable.null);
+  let modalRef = React.useRef(Bindings.Js.Nullable.null);
 
-  [@react.component]
-  let make = (~initialProps as _=?) => {
-    let (modalOpen, setModalOpen) = React.useState(_ => true);
-    let buttonRef = React.useRef(Bindings.Js.Nullable.null);
-    let modalRef = React.useRef(Bindings.Js.Nullable.null);
+  Hooks_useClickOutsideHandler.make(
+    ~reference=modalRef,
+    ~ignoreElements=Some([|buttonRef|]),
+    ~handler=
+      _ =>
+        if (modalOpen) {
+          setModalOpen(_ => false);
+        },
+    (),
+  );
 
-    Hooks_useClickOutsideHandler.make(
-      ~reference=modalRef,
-      ~ignoreElements=Some([|buttonRef|]),
-      ~handler=
-        _ =>
-          if (modalOpen) {
-            setModalOpen(_ => false);
-          },
-      (),
-    );
-    <Components.Layout>
-      <Components.Head>
-        <title> {"Home " |> React.string} </title>
-      </Components.Head>
-      <button
-        ref={ReactDOM.Ref.domRef(buttonRef)}
-        onClick={_ => setModalOpen(_ => true)}>
-        {"Open modal" |> React.string}
-      </button>
-      {modalOpen
-         ? <UniversalPortal_Shared.Components.Portal selector="body">
-             <div className=Styles.modal>
-               <div
-                 ref={ReactDOM.Ref.domRef(modalRef)}
-                 className=Styles.modalContent>
-                 {"Hey, I'm a universal portal, disable JS on your dev tools and check that I'll still here"
-                  |> React.string}
-                 <button
-                   className=Styles.modalButton
-                   onClick={_ => setModalOpen(_ => false)}>
-                   {"Close" |> React.string}
-                 </button>
-               </div>
+  <Components.Layout>
+    <Components.Head>
+      <title> {"Home " |> React.string} </title>
+    </Components.Head>
+    <button
+      ref={ReactDOM.Ref.domRef(buttonRef)}
+      onClick={_ => setModalOpen(_ => true)}>
+      {"Open modal" |> React.string}
+    </button>
+    {modalOpen
+       ? <UniversalPortal_Shared.Components.Portal selector="body">
+           <div className=Styles.modal>
+             <div
+               ref={ReactDOM.Ref.domRef(modalRef)}
+               className=Styles.modalContent>
+               {"Hey, I'm a universal portal, disable JS on your dev tools and check that I'll still here"
+                |> React.string}
+               <button
+                 className=Styles.modalButton
+                 onClick={_ => setModalOpen(_ => false)}>
+                 {"Close" |> React.string}
+               </button>
              </div>
-           </UniversalPortal_Shared.Components.Portal>
-         : React.null}
-    </Components.Layout>;
-  };
+           </div>
+         </UniversalPortal_Shared.Components.Portal>
+       : React.null}
+  </Components.Layout>;
 };

--- a/src/universal/native/lib/Services/Services_GetPokemon.re
+++ b/src/universal/native/lib/Services/Services_GetPokemon.re
@@ -28,58 +28,6 @@ let defaultPokemon = {
               }],
 };
 
-let name = json => json |> member("name") |> to_string;
-let sprites = json => {
-  `Assoc([
-    (
-      "other",
-      `Assoc([
-        (
-          "dream_world",
-          `Assoc([
-            (
-              "front_default",
-              `String(
-                json
-                |> member("sprites")
-                |> member("other")
-                |> member("dream_world")
-                |> member("front_default")
-                |> to_string,
-              ),
-            ),
-          ]),
-        ),
-      ]),
-    ),
-  ]);
-};
-
-let abilities = json => {
-  `List(
-    {
-      json
-      |> member("abilities")
-      |> to_list
-      |> List.map(abil => {
-           `Assoc([
-             (
-               "ability",
-               `Assoc([
-                 (
-                   "name",
-                   `String(
-                     abil |> member("ability") |> member("name") |> to_string,
-                   ),
-                 ),
-               ]),
-             ),
-           ])
-         });
-    },
-  );
-};
-
 let extractSprites = (json): sprites => {
   let front_default_url =
     json

--- a/src/universal/native/native-bidings/Bindings_Dream.re
+++ b/src/universal/native/native-bidings/Bindings_Dream.re
@@ -1,0 +1,3 @@
+type request = Dream.request;
+
+let query = (req, name) => Dream.query(req, name);


### PR DESCRIPTION
## Why?

We have getInitialProps, which is a nice way to keep the logic of initialProps near to markup, but the way to declare te route was a way too complicated:

We had one way to handle it on app.re:
```reason
module type Route = {
  let route: string;
  let getInitialProps:
    option(
      (string => option(string)) =>
      Shared_js_demo.Bindings.Js.Promise.t(Shared_js_demo.Bindings.Json.t),
    );

  [@react.component]
  let make: (~initialProps: Shared_js_demo.Bindings.Json.t=?) => React.element;
};

module Route = (R: Route) => {
  let route = R.route;
  let make = () => {
    (
      initialProps => {
        switch (initialProps) {
        | Some(props) => <R initialProps=props />
        | None => <R />
        };
      },
      Option.is_some(R.getInitialProps),
    );
  };
};

module PokemonRoute = Route(Shared_js_demo.Pages.Pokemon.Make);
module PortalRoute = Route(Shared_js_demo.Pages.Portal.Make);

module Main = {
  [@react.component]
  let make = () => {
    <Routes_handler
      pathMappingDetails={path =>
        switch (path) {
        | route when route == PokemonRoute.route => PokemonRoute.make()
        | route when route == PortalRoute.route => PortalRoute.make()
        | _ =>
          Js.log("No matching route found");
          ((_ => <div />), false);
        }
      }
    />;
  };
};
```

And one way to handle in the server:

```reason
let pokemonRoute =
  Routes_build.make(
    ~route=Shared_native_demo.Pages.Pokemon.Make.route,
    ~renderApp=
      initialProps => <Shared_native_demo.Pages.Pokemon.Make initialProps />,
    ~initialProps=
      switch (Shared_native_demo.Pages.Pokemon.Make.getInitialProps) {
      | Some(getInitialProps) => getInitialProps
      | None => (
          _ => Lwt.return(Shared_native_demo.Bindings.Json.from_string("{}"))
        )
      },
  );

let portalRoute =
  Routes_build.make(
    ~route=Shared_native_demo.Pages.Portal.Make.route,
    ~renderApp=_ => <Shared_native_demo.Pages.Portal.Make />,
    ~initialProps=
      switch (Shared_native_demo.Pages.Portal.Make.getInitialProps) {
      | Some(getInitialProps) => getInitialProps
      | None => (
          _ => Lwt.return(Shared_native_demo.Bindings.Json.from_string("{}"))
        )
      },
  );
  
 ...List.concat([pokemonRoute, portalRoute]),
```

And the page should be wrapper by a Make module:

https://github.com/pedrobslisboa/full-stack-reasonml-advanced-sample/compare/feat/add-dynamic-routing#diff-1d3588694b8dab15a8ac14788a301c490d98093f69d97341c4ff81614543b739L41-L44

We would like to have a easier way to handle it.

## How

This PR adds a new layer inspired by @davesnx

The idea is to have a DynamicRouting which will handle the pages contract and it can be consumed on both server and client to deliver a better experience

We can now do it:

```reason
open DynamicRouting;
loadedRoutes
|> register(
     ~path="/",
     ~getInitialProps=(_) => Binding.Json.from_string("Hello World"),
     ~component=initialProps =>
     <h1> {ReasonReact.string(initialProps |> Binding.Json.to_string)} </h1>
   );
   
// Register more routes here
let loadedPages = getLoadedRoutes();
```

By doing it, there is no need to declare the pages on the app and server as before, we can only register them on the `Pages.re` and be free to check it running.

For now, it has a lot of limitations, but for sure is an improvement.

In the future, I would like to have something like:

```reason
// Pages_Home.re
type props = [%json { name: string }];
let props = {
    name: "John"
};
// let decodedProps = props_of_yojson(props);
// let jsonProps = props_to_yojson(decodedProps);

let getInitialProps = Some(props);

[@react.component]
let make = (~initialProps) => {
    <div> {React.string(initialProps.name)} </div>
}

// Pages.re
loadedRoutes
|> register(Pages_Home);
```

But as you can read on README, I still don't know how and if it's possible, but I will try :3